### PR TITLE
feat(common): add shared configuration and enhance Terragrunt common setup

### DIFF
--- a/common/common.hcl
+++ b/common/common.hcl
@@ -1,0 +1,66 @@
+/*==== 
+Common Terragrunt Configuration 
+=====*/
+
+locals {
+  backend_bucket_name   = "workload-state"
+  backend_key           = "${path_relative_to_include()}.tfstate"
+  backend_region        = "region"
+  backend_encrypt       = true
+  backend_dynamodb_lock = "workload-tfstate-locking"
+
+  # Define shared assume role
+  assume_role_arn = "arn:aws:iam::123456789:role/workload-role"
+}
+
+# Inputs consolidating the values from locals
+inputs = {
+  aws_region      = local.backend_region
+  assume_role_arn = local.assume_role_arn
+}
+
+# Generate Terraform version requirements
+generate "versions" {
+  path      = "versions.tf"
+  if_exists = "skip"
+  contents  = <<EOF
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+EOF
+}
+
+# Generate provider configuration
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "skip"
+  contents  = <<EOF
+provider "aws" {
+  region = var.aws_region
+
+  assume_role {
+    role_arn = var.assume_role_arn
+  }
+
+  skip_credentials_validation = true
+  skip_region_validation      = true
+}
+
+variable "aws_region" {
+  description = "AWS region for infrastructure"
+  type        = string
+}
+
+variable "assume_role_arn" {
+  description = "IAM role ARN to assume"
+  type        = string
+}
+EOF
+}

--- a/common/env.yaml
+++ b/common/env.yaml
@@ -1,0 +1,19 @@
+environments:
+  sg:
+    aws_region: "ap-southeast-1"
+    assume_role_arn: "arn:aws:iam::123456789:role/workload-role"
+  id:
+    aws_region: "ap-southeast-3"
+    assume_role_arn: "arn:aws:iam::123456789:role/workload-role"
+  global:
+    aws_region: "us-east-1"
+    assume_role_arn: "arn:aws:iam::123456789:role/workload-role"
+  us:
+    aws_region: "us-east-1"
+    assume_role_arn: "arn:aws:iam::123456789:role/workload-role"
+  eu:
+    aws_region: "eu-west-1"
+    assume_role_arn: "arn:aws:iam::123456789:role/workload-role"
+  au:
+    aws_region: "ap-southeast-2"
+    assume_role_arn: "arn:aws:iam::123456789:role/workload-role"


### PR DESCRIPTION
- Introduced  for shared Terragrunt configurations:
  - Includes backend S3 bucket, region, and DynamoDB locking setup.
- Added  for centralized environment-specific variables:
  - Maps AWS regions dynamically based on environment keys.
- Enhanced configuration reusability by dynamically loading shared variables.